### PR TITLE
chore(deploy): add Netlify SPA redirect + build config

### DIFF
--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,0 +1,4 @@
+# SPA fallback: every route serves index.html so React Router
+# can handle it client-side (fixes 404 on refresh / direct links
+# like /forgot-password, /orders, /admin, etc.)
+/*    /index.html   200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,16 @@
+# Netlify build config for the React (Vite) frontend.
+# The backend (server/) is NOT deployed here — it runs separately
+# on Render. The frontend reaches it via the VITE_API_URL env var
+# (set in Netlify: Site settings -> Environment variables).
+
+[build]
+  base = "frontend"
+  command = "npm run build"
+  publish = "dist"
+
+# SPA fallback (same effect as public/_redirects; kept here too
+# so the rule is version-controlled even if the file is missed).
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
- frontend/public/_redirects: serve index.html for all routes so React Router deep links (/forgot-password, /orders, ...) don't 404
- netlify.toml: explicit base=frontend, build, publish=dist + the same SPA redirect, version-controlled